### PR TITLE
Support Saloon v4 alongside v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.2",
         "illuminate/collections": "^10 || ^11",
-        "saloonphp/saloon": "^3.0"
+        "saloonphp/saloon": "^3.0 || ^4.0"
     },
     "require-dev": {
         "laravel/pint": "^1.13",


### PR DESCRIPTION
Widen the saloonphp/saloon constraint to ^3.0 || ^4.0. None of the v4 breaking changes (OAuth serialization, base-URL override, fixture path traversal) affect this library, so both versions are compatible.